### PR TITLE
allowed for social icons to be blank

### DIFF
--- a/layouts/partials/socialbtns.html
+++ b/layouts/partials/socialbtns.html
@@ -1,12 +1,20 @@
+{{ if .Site.Params.email }}
 <a class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon mdl-mini-footer--social-btn social-btn" href="mailto:{{ .Site.Params.email }}?subject=Hi">
     <i class="material-icons_lg icon ion-email"></i>
     <span class="visuallyhidden">Email</span>
 </a>
+{{ end }}
+
+{{ if .Site.Params.github}}
 <a class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon mdl-mini-footer--social-btn social-btn" href="{{ .Site.Params.github }}">
     <i class="material-icons_lg icon ion-social-github"></i>
     <span class="visuallyhidden">Github</span>
 </a>
+{{ end }}
+
+{{ if .Site.Params.twitter }}
 <a class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon mdl-mini-footer--social-btn social-btn" href="{{ .Site.Params.twitter }}">
-    <i class="material-icons_lg icon ion-social-twitter "></i>                        
+    <i class="material-icons_lg icon ion-social-twitter "></i>
     <span class="visuallyhidden">Twitter</span>
 </a>
+{{ end }}


### PR DESCRIPTION
First off: Awesome design for the template!

This pull request allows a user to not specify a twitter, github, or email.
If the user does not specify a specific social address, then the icon for the social address is not visible.

Before the template would still have the icon with a blank link