### PR TITLE
Use relative URLs

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
                     <div class="mdl-card__list-item mdl-color-text--grey-600">
                         <div class="hmdl-page-meta">
                             {{- with .Params.author.image }}
-                            <div class="minilogo" style="background-image: url('{{  .  | relURL }}' );"></div>
+                            <div class="minilogo" style="background-image: url('{{  .  | relURL }}');"></div>
                             {{- end }}
                             <div>
                                 <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
                     <div class="mdl-card__list-item mdl-color-text--grey-600">
                         <div class="hmdl-page-meta">
                             {{- with .Params.author.image }}
-                            <div class="minilogo" style="background-image: url('{{  .  | relURL }}');"></div>
+                            <div class="minilogo" style="background-image: url('{{ . | relURL }}');"></div>
                             {{- end }}
                             <div>
                                 <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
                     <div class="mdl-card__list-item mdl-color-text--grey-600">
                         <div class="hmdl-page-meta">
                             {{- with .Params.author.image }}
-                            <div class="minilogo" style="background-image: url('{{ . }}');"></div>
+                            <div class="minilogo" style="background-image: url('{{  .  | relURL }}' );"></div>
                             {{- end }}
                             <div>
                                 <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,12 +1,12 @@
             {{- partial "header.html" . }}
             <div class="hmdl-page mdl-grid">
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
-                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3 {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</h3>
                     </div>
                     <div class="hmdl-page-meta mdl-color-text--grey-700 mdl-card__supporting-text">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}');"></div>
                         {{- end }}
                         <div>
                             <strong>{{ .Params.author.name }}</strong>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,12 +1,12 @@
             {{- partial "header.html" . }}
             <div class="hmdl-page mdl-grid">
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
-                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{.}}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3 {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</h3>
                     </div>
                     <div class="hmdl-page-meta mdl-color-text--grey-700 mdl-card__supporting-text">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{.}}');"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
                         {{- end }}
                         <div>
                             <strong>{{ .Params.author.name }}</strong>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,10 +17,10 @@
                     <div class="hmdl-page-content mdl-color-text--grey-700 mdl-card__supporting-text">
                         {{ .Content }}
                     </div>
-                    <div class="hmdl-page-comments mdl-color-text--primary-contrast mdl-card__supporting-text comments"> 
+                    <div class="hmdl-page-comments mdl-color-text--primary-contrast mdl-card__supporting-text comments">
                         <a href={{ .Params.author.website }}>{{ .Params.author.name }}</a>
                         <p>{{ .Params.author.description }}</p>
-                    </div>  
+                    </div>
                 </div>
             </div>
             {{- partial "footer.html" . }}

--- a/layouts/about/single.html
+++ b/layouts/about/single.html
@@ -3,7 +3,7 @@
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
                     <div id="hmdl-about-media" class="hmdl-page-banner mdl-card__media about-media" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <div class="profile-pic-container">
-                            <div class="profilepic" style="background-image: url('{{  .Site.Params.avatar  | relURL }}');"></div>
+                            <div class="profilepic" style="background-image: url('{{ .Site.Params.avatar | relURL }}');"></div>
                         </div>
                     </div>
 

--- a/layouts/about/single.html
+++ b/layouts/about/single.html
@@ -1,9 +1,9 @@
             {{- partial "header.html" . }}
             <div class="hmdl-page hmdl-about mdl-grid">
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
-                    <div id="hmdl-about-media" class="hmdl-page-banner mdl-card__media about-media" style="{{with .Params.cardheaderimage}}background-image: url('{{.}}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div id="hmdl-about-media" class="hmdl-page-banner mdl-card__media about-media" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <div class="profile-pic-container">
-                            <div class="profilepic" style="background-image: url('{{ .Site.Params.avatar }}');"></div>
+                            <div class="profilepic" style="background-image: url('{{  .Site.Params.avatar  | relURL }}' );"></div>
                         </div>
                     </div>
 

--- a/layouts/about/single.html
+++ b/layouts/about/single.html
@@ -1,9 +1,9 @@
             {{- partial "header.html" . }}
             <div class="hmdl-page hmdl-about mdl-grid">
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
-                    <div id="hmdl-about-media" class="hmdl-page-banner mdl-card__media about-media" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div id="hmdl-about-media" class="hmdl-page-banner mdl-card__media about-media" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <div class="profile-pic-container">
-                            <div class="profilepic" style="background-image: url('{{  .Site.Params.avatar  | relURL }}' );"></div>
+                            <div class="profilepic" style="background-image: url('{{  .Site.Params.avatar  | relURL }}');"></div>
                         </div>
                     </div>
 

--- a/layouts/partials/fab-buttons.html
+++ b/layouts/partials/fab-buttons.html
@@ -1,24 +1,24 @@
                     <!-- Actual buttons that fly out -->
                     <div id="fab_ctn" class="mdl-button--fab_flinger-container">
-                        
+
                         <button id="fab_btn" class="mdl-button mdl-js-ripple-effect mdl-js-button mdl-button--fab mdl-color--accent">
                             <i class="icon ion-android-add mdl-color-text--white" role="presentation"></i>
                             <span class="visuallyhidden">add</span>
                         </button>
-                        
+
                         <div class="mdl-button--fab_flinger-options">
-                            <a href="/about">
+                            <a href={{ "/about" | relURL }}>
                                 <button id="about" class="mdl-button mdl-js-button mdl-button--fab mdl-js-ripple-effect mdl-color--primary" title="About Me">
                                     <i class="icon ion-person mdl-color-text--white" role="presentation"></i>
                                 </button>
                             </a>
-                            
-                            <a href="/project">
+
+                            <a href={{ "/project" | relURL }}>
                                 <button id="projects" class="mdl-button mdl-js-button mdl-button--fab mdl-js-ripple-effect mdl-color--primary" title="My Projects">
                                     <i class="icon ion-code mdl-color-text--white" role="presentation"></i>
                                 </button>
                             </a>
-                            
+
                             <a href="mailto:{{ .Site.Params.email }}?subject=Hi">
                                 <button id="email" class="mdl-button mdl-js-button mdl-button--fab mdl-js-ripple-effect mdl-color--primary" title="Email Me">
                                     <i class="icon ion-email mdl-color-text--white" role="presentation"></i>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,8 +21,8 @@
     </script>
     {{- end }}
     {{- if .IsNode }}
-    <script src="/js/cardmedia.js"></script>
-    <script src="/js/fabbutton.js"></script>
+    <script src={{ "/js/cardmedia.js" | relURL }}></script>
+    <script src={{ "/js/fabbutton.js" | relURL }}></script>
     {{- end }}
     {{- partial "extra-footer.html" . }}
 </body>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
     <title>{{ .Title }}</title>
 </head>
 <!-- TODO: rethink background -->
-<body style="background-image: url('{{  .Site.Params.background  | relURL }}');">
+<body style="background-image: url('{{ .Site.Params.background | relURL }}');">
     <div class="hmdl-body mdl-layout mdl-js-layout has-drawer is-upgraded">
         {{- if not (and .IsPage (eq .Type "presentation")) }}
             {{- partial "navbar.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
     <title>{{ .Title }}</title>
 </head>
 <!-- TODO: rethink background -->
-<body style="background-image: url('{{ .Site.Params.background }}');">
+<body style="background-image: url('{{  .Site.Params.background  | relURL }}' );">
     <div class="hmdl-body mdl-layout mdl-js-layout has-drawer is-upgraded">
         {{- if not (and .IsPage (eq .Type "presentation")) }}
             {{- partial "navbar.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,7 +14,7 @@
     {{- else }}
         {{- $.Scratch.Set "favicon" "/images/favicon.ico" }}
     {{- end }}
-    <link rel="icon" type="image/png" href="{{ $.Scratch.Get "favicon" }}">
+    <link rel="icon" type="image/png" href="{{ $.Scratch.Get "favicon" | relURL }}">
 
     <!-- Add to homescreen for Chrome on Android -->
     <meta name="mobile-web-app-capable" content="yes">
@@ -43,12 +43,12 @@
     {{- end -}}
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en"/>
-    <link rel="stylesheet" href="/css/ionicons.min.css"/>
+    <link rel="stylesheet" href={{ "/css/ionicons.min.css" | relURL }}/>
     <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.1.3/material.{{ $.Scratch.Get "mdlPrimary" }}-{{ $.Scratch.Get "mdlAccent" }}.min.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="/css/hmdl-style.css"/>
+    <link rel="stylesheet" href={{ "/css/hmdl-style.css" | relURL }}/>
     {{- if and .IsPage (eq .Type "presentation") }}
-    <link rel="stylesheet" href="/css/remark.css" />
+    <link rel="stylesheet" href={{ "/css/remark.css" | relURL }}/>
     {{- end }}
 
     {{- partial "extra-header.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,7 +18,7 @@
 
     <!-- Add to homescreen for Chrome on Android -->
     <meta name="mobile-web-app-capable" content="yes">
-    <link rel="icon" sizes="192x192" href="images/touch/chrome-touch-icon-192x192.png">
+    <link rel="icon" sizes="192x192" href="{{ .Site.BaseURL }}images/touch/chrome-touch-icon-192x192.png">
 
     <!-- Add to homescreen for Safari on iOS -->
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -27,7 +27,7 @@
     <link rel="apple-touch-icon-precomposed" href="apple-touch-icon-precomposed.png">
 
     <!-- Tile icon for Win8 (144x144 + tile color) -->
-    <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
+    <meta name="msapplication-TileImage" content="{{ .Site.BaseURL }}images/touch/ms-touch-icon-144x144-precomposed.png">
     <meta name="msapplication-TileColor" content="#3372DF">
 
     <!-- Allow user to choose MDL theme -->
@@ -43,12 +43,12 @@
     {{- end -}}
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en"/>
-    <link rel="stylesheet" href={{ "/css/ionicons.min.css" | relURL }}/>
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/ionicons.min.css"/>
     <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.1.3/material.{{ $.Scratch.Get "mdlPrimary" }}-{{ $.Scratch.Get "mdlAccent" }}.min.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href={{ "/css/hmdl-style.css" | relURL }}/>
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/hmdl-style.css"/>
     {{- if and .IsPage (eq .Type "presentation") }}
-    <link rel="stylesheet" href={{ "/css/remark.css" | relURL }}/>
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/remark.css"/>
     {{- end }}
 
     {{- partial "extra-header.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,7 +14,7 @@
     {{- else }}
         {{- $.Scratch.Set "favicon" "/images/favicon.ico" }}
     {{- end }}
-    <link rel="icon" type="image/png" href="{{ $.Scratch.Get "favicon" | relURL }}">
+    <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}{{ $.Scratch.Get "favicon" }}">
 
     <!-- Add to homescreen for Chrome on Android -->
     <meta name="mobile-web-app-capable" content="yes">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,7 +56,7 @@
     <title>{{ .Title }}</title>
 </head>
 <!-- TODO: rethink background -->
-<body style="background-image: url('{{  .Site.Params.background  | relURL }}' );">
+<body style="background-image: url('{{  .Site.Params.background  | relURL }}');">
     <div class="hmdl-body mdl-layout mdl-js-layout has-drawer is-upgraded">
         {{- if not (and .IsPage (eq .Type "presentation")) }}
             {{- partial "navbar.html" . }}

--- a/layouts/partials/profile.html
+++ b/layouts/partials/profile.html
@@ -1,6 +1,6 @@
                 <!-- Card to display blogger's name, contact, etc -->
                 <div class="hmdl-profile-card mdl-card profile-card mdl-cell mdl-cell--8-col mdl-cell--4-col-desktop">
-                    <div class="mdl-card__media mdl-color--white mdl-color-text--grey-600" style="background-image: url('{{ .Site.Params.image }}');">
+                    <div class="mdl-card__media mdl-color--white mdl-color-text--grey-600" style="background-image: url('{{  .Site.Params.image  | relURL }}' );">
                     </div>
                     {{- partial "fab-buttons" . }}
                     <div class="hmdl-page-meta mdl-card__supporting-text meta--fill mdl-color-text--grey-600 ">

--- a/layouts/partials/profile.html
+++ b/layouts/partials/profile.html
@@ -1,6 +1,6 @@
                 <!-- Card to display blogger's name, contact, etc -->
                 <div class="hmdl-profile-card mdl-card profile-card mdl-cell mdl-cell--8-col mdl-cell--4-col-desktop">
-                    <div class="mdl-card__media mdl-color--white mdl-color-text--grey-600" style="background-image: url('{{  .Site.Params.image  | relURL }}' );">
+                    <div class="mdl-card__media mdl-color--white mdl-color-text--grey-600" style="background-image: url('{{  .Site.Params.image  | relURL }}');">
                     </div>
                     {{- partial "fab-buttons" . }}
                     <div class="hmdl-page-meta mdl-card__supporting-text meta--fill mdl-color-text--grey-600 ">

--- a/layouts/partials/showallposts.html
+++ b/layouts/partials/showallposts.html
@@ -1,7 +1,7 @@
                 <!-- Link to show the rest of the posts -->
                 <nav class="mdl-cell mdl-cell--12-col">
                     <div class="section-spacer"></div>
-                    <a href="/post/" title="show more">
+                    <a href={{ "/post/" | relURL }} title="show more">
                         More
                         <button class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon">
                             <i class="material-icons icon ion-android-arrow-forward" role="presentation"></i>

--- a/layouts/post/card-12.html
+++ b/layouts/post/card-12.html
@@ -1,6 +1,6 @@
                 <!-- Make a card view for posts -->
                 <div class="mdl-card mdl-cell mdl-cell--12-col">
-                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background-image: url('{{ . | relURL }}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3><a href="{{ .RelPermalink }}" {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</a></h3>
                     </div>
                     <div class="mdl-card__supporting-text mdl-color-text--grey-600">
@@ -8,7 +8,7 @@
                     </div>
                     <div class="hmdl-page-meta mdl-card__supporting-text mdl-color-text--grey-600">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}');"></div>
                         {{- end }}
                         <div>
                             <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/post/card-12.html
+++ b/layouts/post/card-12.html
@@ -1,6 +1,6 @@
                 <!-- Make a card view for posts -->
                 <div class="mdl-card mdl-cell mdl-cell--12-col">
-                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background-image: url('{{.}}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3><a href="{{ .RelPermalink }}" {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</a></h3>
                     </div>
                     <div class="mdl-card__supporting-text mdl-color-text--grey-600">
@@ -8,7 +8,7 @@
                     </div>
                     <div class="hmdl-page-meta mdl-card__supporting-text mdl-color-text--grey-600">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{.}}');"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
                         {{- end }}
                         <div>
                             <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/post/card-8.html
+++ b/layouts/post/card-8.html
@@ -1,6 +1,6 @@
                 <!-- Make a card view for posts -->
                 <div class="mdl-card mdl-cell mdl-cell--8-col">
-                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background-image: url('{{.}}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3><a href="{{ .RelPermalink }}" {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</a></h3>
                     </div>
                     <div class="mdl-card__supporting-text mdl-color-text--grey-600">
@@ -8,7 +8,7 @@
                     </div>
                     <div class="hmdl-page-meta mdl-card__supporting-text mdl-color-text--grey-600">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{.}}');"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
                         {{- end }}
                         <div>
                             <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/post/card-8.html
+++ b/layouts/post/card-8.html
@@ -1,6 +1,6 @@
                 <!-- Make a card view for posts -->
                 <div class="mdl-card mdl-cell mdl-cell--8-col">
-                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background-image: url('{{ . | relURL }}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3><a href="{{ .RelPermalink }}" {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</a></h3>
                     </div>
                     <div class="mdl-card__supporting-text mdl-color-text--grey-600">
@@ -8,7 +8,7 @@
                     </div>
                     <div class="hmdl-page-meta mdl-card__supporting-text mdl-color-text--grey-600">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}');"></div>
                         {{- end }}
                         <div>
                             <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/post/listitem.html
+++ b/layouts/post/listitem.html
@@ -2,7 +2,7 @@
                     <div class="mdl-card__list-item mdl-color-text--grey-600">
                         <div class="hmdl-page-meta">
                             {{- with .Params.author.image }}
-                            <div class="minilogo" style="background-image: url('{{.}}');"></div>
+                            <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
                             {{- end }}
                             <div>
                                 <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/post/listitem.html
+++ b/layouts/post/listitem.html
@@ -2,7 +2,7 @@
                     <div class="mdl-card__list-item mdl-color-text--grey-600">
                         <div class="hmdl-page-meta">
                             {{- with .Params.author.image }}
-                            <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
+                            <div class="minilogo" style="background-image: url('{{ . | relURL }}');"></div>
                             {{- end }}
                             <div>
                                 <strong><a href="{{ .Params.author.website }}">{{ .Params.author.name }}</a></strong>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,12 +1,12 @@
             {{- partial "header.html" . }}
             <div class="hmdl-page mdl-grid">
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
-                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3 {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</h3>
                     </div>
                     <div class="hmdl-page-meta mdl-color-text--grey-700 mdl-card__supporting-text">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}');"></div>
                         {{- end }}
                         <div>
                             <strong>{{ .Params.author.name }}</strong>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,12 +1,12 @@
             {{- partial "header.html" . }}
             <div class="hmdl-page mdl-grid">
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
-                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{.}}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3 {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</h3>
                     </div>
                     <div class="hmdl-page-meta mdl-color-text--grey-700 mdl-card__supporting-text">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{.}}');"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
                         {{- end }}
                         <div>
                             <strong>{{ .Params.author.name }}</strong>

--- a/layouts/project/project-card.html
+++ b/layouts/project/project-card.html
@@ -1,6 +1,6 @@
                 <!-- Make a card view for projects -->
                 <div class="mdl-card mdl-cell mdl-cell--4-col mdl-shadow--2dp project-card">
-                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background: url('{{ . | relURL }}' ); background-size: cover;{{end}}{{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background: url('{{ . | relURL }}'); background-size: cover;{{end}}{{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <div class="project-title"><a href="{{ .RelPermalink }}" {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</a></div>
                     </div>
                     <div class="mdl-card__actions mdl-card--border">

--- a/layouts/project/project-card.html
+++ b/layouts/project/project-card.html
@@ -1,6 +1,6 @@
                 <!-- Make a card view for projects -->
                 <div class="mdl-card mdl-cell mdl-cell--4-col mdl-shadow--2dp project-card">
-                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background: url('{{.}}'); background-size: cover;{{end}}{{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardthumbimage}}background: url('{{ . | relURL }}' ); background-size: cover;{{end}}{{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <div class="project-title"><a href="{{ .RelPermalink }}" {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</a></div>
                     </div>
                     <div class="mdl-card__actions mdl-card--border">

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -1,12 +1,12 @@
             {{- partial "header.html" . }}
             <div class="hmdl-page mdl-grid">
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
-                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3 {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</h3>
                     </div>
                     <div class="hmdl-page-meta mdl-color-text--grey-700 mdl-card__supporting-text">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}');"></div>
                         {{- end }}
                         <div>
                             <strong>{{ .Params.author.name }}</strong>

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -1,12 +1,12 @@
             {{- partial "header.html" . }}
             <div class="hmdl-page mdl-grid">
                 <div class="mdl-card mdl-shadow--4dp mdl-cell mdl-cell--12-col">
-                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{.}}');{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
+                    <div class="hmdl-page-banner mdl-card__media mdl-color-text--grey-50" style="{{with .Params.cardheaderimage}}background-image: url('{{ . | relURL }}' );{{end}} {{with .Params.cardbackground}}background-color:{{.}};{{end}}">
                         <h3 {{ with .Params.cardtitlecolor }}style="color:{{.}};"{{end}}>{{ title .Title }}</h3>
                     </div>
                     <div class="hmdl-page-meta mdl-color-text--grey-700 mdl-card__supporting-text">
                         {{- with .Params.author.image }}
-                        <div class="minilogo" style="background-image: url('{{.}}');"></div>
+                        <div class="minilogo" style="background-image: url('{{ . | relURL }}' );"></div>
                         {{- end }}
                         <div>
                             <strong>{{ .Params.author.name }}</strong>


### PR DESCRIPTION
### Summary
Fix issue #11 by using relative URLs for all inner-site links/refs. 
This makes the theme appear correctly when we use **HugoMDL** with a `BaseURL` like `www.example.com/hugo-is-awesome/`

### Testing steps:
1. Set `BaseUrl` to "http://127.0.0.1/banana/"
1. Ran `http-server`
1. Site has no style
1. Moved generated files from `public` to `public/banana`
1. Style is back!